### PR TITLE
chore: add agent guidance and specs

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: maintenance
+description: Bring repository health back to target state by checking dependencies, tests, docs, specs, extension behavior, and cleanup opportunities.
+user_invocable: true
+---
+
+# Maintenance
+
+Use this skill when the user asks for maintenance, repository health work, a
+pre-release maintenance pass, or dependency and docs cleanup.
+
+## Goal
+
+The repository is healthy enough for continued feature work or release
+preparation: dependencies are understood, checks are green, docs/specs match
+the extension, and avoidable code drift has been removed.
+
+## Outcomes
+
+- Dependencies are current enough for the release target, with advisories
+  resolved or explicitly tracked.
+- `npm run compile`, `npm run lint`, and `npm test` pass.
+- `README.md`, `CHANGELOG.md`, `package.json`, and `specs/` agree with the
+  current extension behavior.
+- The preview command and sample Handlebars rendering have been smoke tested
+  when the pass touches runtime behavior.
+- Dead code, stale comments, unused dependencies, and needless abstractions in
+  touched areas are removed.
+- Deferred work is recorded with scope, reproduction steps, and rationale.
+
+## Guidance
+
+- Treat each maintenance area as a desired state, not a rigid script.
+- Prefer fixing small issues immediately over collecting them into a report.
+- Keep dependency upgrades incremental enough to review.
+- Split large breaking upgrades or broad refactors into tracked follow-up work
+  when they would obscure the maintenance pass.
+- Verify after each meaningful fix so regressions stay local.
+- Report any remaining risk plainly, including checks that could not be run.
+
+## Useful Commands
+
+```bash
+npm outdated
+npm audit
+npm install
+npm run compile
+npm run lint
+npm test
+npm run package
+```

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ship
+description: Bring a change to shippable quality for this VS Code extension, including verification, docs/spec alignment, packaging confidence, and PR readiness.
+user_invocable: true
+---
+
+# Ship
+
+Use this skill when the user asks to ship, ship it, prepare a PR, or take a
+finished change through final verification.
+
+## Goal
+
+The current change is safe to publish or review: behavior is implemented,
+tests pass, docs and specs match reality, packaging works when relevant, and no
+known blocker is hidden.
+
+## Outcomes
+
+- The branch contains one focused, reviewable change.
+- Changed behavior is covered by tests or an explicit smoke test.
+- `npm run compile`, `npm run lint`, and `npm test` pass.
+- User-facing behavior changes update `README.md` and `CHANGELOG.md`.
+- Durable behavior changes update the relevant file in `specs/`.
+- `package.json` and `package-lock.json` remain consistent.
+- Security and robustness risks from template input, JSON data, and webview
+  output have been considered.
+- The extension has been smoke tested when commands, preview lifecycle, or
+  rendering behavior changed.
+- The PR or handoff summary clearly states what changed, why, risk, and tests.
+
+## Guidance
+
+- Start by understanding the diff against the default branch and the user's
+  requested scope.
+- Fix issues as they are found instead of reporting a checklist.
+- Add missing tests before declaring the change ready.
+- Keep simplification scoped to changed areas unless the user asked for a
+  broader cleanup.
+- If local verification cannot run, explain the blocker and what remains
+  unverified.
+- Never claim an issue is fully closed unless every relevant task is complete.
+
+## Useful Commands
+
+```bash
+git status --short --branch
+git diff --stat
+npm run compile
+npm run lint
+npm test
+npm run package
+```

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,7 @@ yarn.lock
 Makefile
 *.vsix
 node_modules
+AGENTS.md
+CLAUDE.md
+.agents/**
+specs/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+## Coding Agent Guidance
+
+### Style
+
+Be concise. Read the relevant code before changing it. Prefer small,
+reviewable changes that leave the extension runnable locally.
+
+### Critical Thinking
+
+- Fix root causes instead of hiding symptoms.
+- If behavior is unclear, read more code and tests first; ask only when the
+  next step would be risky.
+- Treat unrecognized working-tree changes as user-owned. Work around them and
+  do not revert them unless explicitly asked.
+- Keep implementation, tests, docs, and specs in sync.
+
+### Project Shape
+
+This is a VS Code extension that renders a live Handlebars preview. The
+runtime code lives in `src/`, tests live in `src/test/`, and extension metadata
+and commands live in `package.json`.
+
+### Specs
+
+`specs/` contains durable project expectations. New work should follow the
+specs or update them in the same change when behavior intentionally changes.
+
+| Spec | Description |
+| --- | --- |
+| architecture | Extension boundaries, preview lifecycle, rendering flow |
+| testing | Unit and integration test expectations |
+| release-process | Packaging, publishing, and release checks |
+| maintenance | Periodic health requirements for dependencies, docs, tests, and CI |
+
+### Local Development
+
+```bash
+npm install
+npm run compile
+npm run lint
+npm test
+```
+
+Use `npm run watch` while iterating on the extension bundle.
+
+### Quality Bar
+
+- Run `npm run compile`, `npm run lint`, and `npm test` before shipping code
+  changes.
+- Add or update tests when rendering behavior, preview panel behavior, command
+  activation, file watching, or data loading changes.
+- Smoke test user-facing extension behavior when a change affects commands,
+  preview rendering, or VS Code integration.
+- Keep `README.md`, `CHANGELOG.md`, `package.json`, and specs accurate when
+  public behavior changes.
+
+### Testing Notes
+
+- Rendering logic belongs in focused tests under `src/test/suite/lib/`.
+- Extension command and VS Code integration behavior belongs in
+  `src/test/suite/`.
+- Prefer observable results over implementation-detail assertions.
+- When fixing a bug, add a regression test that would have failed before the
+  fix when practical.
+
+### Security And Robustness
+
+- Treat template contents and adjacent JSON data files as user input.
+- Avoid script execution or filesystem access beyond the files needed for the
+  preview.
+- Escape or constrain webview content according to VS Code webview guidance.
+- Report errors in a useful way without exposing unnecessary internals.
+
+### Pull Requests
+
+- Keep PRs focused on one concern.
+- Use conventional commit-style titles when possible, for example
+  `fix(preview): handle missing data files`.
+- Do not merge while required checks are failing.
+- If a change only completes part of an issue, avoid closing keywords until the
+  whole issue is actually complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,0 +1,34 @@
+# Architecture
+
+## Status
+
+Active
+
+## Purpose
+
+Define the durable boundaries of the Handlebars Preview extension so feature
+work stays small, testable, and aligned with VS Code extension behavior.
+
+## Requirements
+
+- Extension activation remains command-driven through `handlebars.preview`.
+- Command wiring and VS Code API integration belong near `src/extension.ts`.
+- Preview panel state, lifecycle, editor subscriptions, and webview updates
+  belong in `src/lib/PreviewPanel.ts`.
+- Template rendering and data loading belong in focused library code under
+  `src/lib/`.
+- Rendering code must be usable from tests without requiring a running VS Code
+  window when practical.
+- The preview data file convention remains `template.handlebars.json` unless a
+  behavior change updates docs, tests, and this spec together.
+- Webview output should be generated from compiled Handlebars and the matching
+  JSON context; missing or invalid context should fail predictably and be
+  covered by tests.
+
+## Design Principles
+
+- Keep the extension surface small: command, preview panel, renderer.
+- Prefer direct TypeScript types over ad hoc stringly APIs.
+- Keep VS Code-specific objects at the boundary so rendering remains easy to
+  test.
+- Avoid speculative extension points until a real feature needs them.

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -1,0 +1,59 @@
+# Maintenance
+
+## Status
+
+Active
+
+## Purpose
+
+Keep the extension healthy between feature releases by preventing dependency
+rot, stale docs, and untested behavior from accumulating.
+
+## When To Run
+
+- Before each minor or major release.
+- Quarterly during quiet periods.
+- After large feature or dependency changes.
+
+## Requirements
+
+### Dependencies
+
+- Direct dependencies and dev dependencies are reviewed for current versions.
+- Security advisories are checked and resolved or explicitly tracked.
+- `package-lock.json` stays consistent with `package.json`.
+- Major dependency upgrades are allowed when they keep the extension working;
+  large migrations may be split into tracked follow-up work.
+
+### Tests
+
+- Compile, lint, and test gates pass.
+- Recent feature areas have meaningful coverage.
+- Fixtures still represent documented usage.
+
+### Documentation
+
+- `README.md` matches current commands, keybindings, data-file behavior, and
+  limitations.
+- `CHANGELOG.md` records user-visible changes since the previous release.
+- Specs reflect the current architecture and release expectations.
+
+### Code Quality
+
+- Dead code, stale comments, and unused dependencies are removed.
+- Repeated patterns are consolidated when doing so simplifies the code.
+- Names describe user-facing concepts and extension responsibilities clearly.
+- No speculative abstractions are kept without a current use.
+
+### Extension Behavior
+
+- The preview command works in an Extension Development Host.
+- A sample `.handlebars` file renders with adjacent JSON context.
+- Missing or invalid context fails in a way users can understand.
+- Webview behavior remains compatible with the supported VS Code engine.
+
+## Deferred Items
+
+Issues found during maintenance may be deferred only when they are too large or
+too risky to fix inline. Deferred work should have a clear issue or note with
+scope, reproduction steps, and the reason it was not included.

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -1,0 +1,31 @@
+# Release Process
+
+## Status
+
+Active
+
+## Purpose
+
+Define the release expectations for publishing the VS Code extension.
+
+## Requirements
+
+- Release changes must pass `npm run compile`, `npm run lint`, and `npm test`.
+- Public behavior changes must be reflected in `README.md` and `CHANGELOG.md`.
+- `package.json` metadata, commands, keybindings, and version must match the
+  release being published.
+- Package validation should run with `npm run package` before publishing.
+- Publish with `npm run publish` only after checks pass and the package contents
+  have been reviewed.
+
+## Versioning
+
+- Patch releases are for bug fixes and maintenance.
+- Minor releases are for user-visible features or behavior improvements.
+- Major releases are for breaking behavior or VS Code engine changes that may
+  require user action.
+
+## Release Readiness
+
+A release is ready when the package installs, the preview command opens, sample
+templates render correctly, and docs describe the shipped behavior.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -1,0 +1,38 @@
+# Testing
+
+## Status
+
+Active
+
+## Purpose
+
+Define the minimum confidence expected before changes are shipped.
+
+## Requirements
+
+- `npm run compile` must pass for TypeScript and bundling changes.
+- `npm run lint` must pass for source changes.
+- `npm test` must pass before shipping code changes.
+- Rendering changes need focused tests that assert rendered output or expected
+  failure behavior.
+- VS Code command or panel lifecycle changes need integration tests when the
+  behavior can be exercised by the extension test harness.
+- Bug fixes should include regression tests when practical.
+
+## Smoke Testing
+
+For user-facing changes, manually verify the extension in a VS Code Extension
+Development Host:
+
+- Open a `.handlebars` file.
+- Run `Handlebars: Open Preview`.
+- Confirm preview rendering uses the adjacent `.handlebars.json` file.
+- Confirm edits to the template or data refresh the preview when the changed
+  area is affected.
+
+## Test Design
+
+- Prefer tests based on observable output and state.
+- Avoid assertions that only prove an internal helper was called.
+- Keep test examples small and readable.
+- Update fixtures in `src/test/examples/` when they clarify real user behavior.


### PR DESCRIPTION
## What
- Add repo-specific AGENTS/CLAUDE guidance for coding agents
- Add lightweight specs for architecture, testing, release process, and maintenance
- Add goal-oriented ship and maintenance skills
- Exclude repo-only agent/spec files from packaged VSIX output

## Why
Adopts the useful guidance/spec/skill ideas from everruns/bashkit while keeping only the parts relevant to this VS Code extension.

## How
The guidance is tailored to the existing TypeScript extension commands, test layout, VS Code preview behavior, and npm/vsce packaging flow.

## Verification
- npm run compile
- npm run lint
- npm test
- npm run package

## Risk
Low. This is repo guidance and packaging metadata only; runtime extension code is unchanged.