### PR TITLE
feat(preview): support custom handlebars helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add regression coverage for missing/invalid JSON context, escaped render errors, preview command wiring, and rendered preview output.
 - Add GitHub Actions CI for compile, lint, desktop tests, web tests, audit, and package validation.
 - Add `Handlebars: Load Partials` for workspace-configured partial files.
+- Add opt-in custom helper loading for trusted desktop workspaces through
+  `handlebarsPreview.unsafeHelpers.*` settings.
 
 ## [1.3.1] - 2022-07-19
 - Extension now contributes to Explorer context menu

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 - Contributes `.handlebars` and `.hbs` language recognition.
 - Support for partials selected from the command palette.
 - Support for local `@font-face` fonts referenced from the template directory.
+- Optional custom helper support from trusted workspace JavaScript.
 - Preview webviews run with scripts disabled and a restrictive content security policy.
 
 ## Example
@@ -26,6 +27,40 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 - By default, preview data is read from the template file name plus `.json`, such as `email.handlebars.json`.
 - To register partials for preview rendering, run `Handlebars: Load Partials` and select one or more partial files. Each partial is available by its file basename.
 - Local font files referenced from inline styles, `<style>` blocks, local stylesheet links, or local CSS imports can load when they are inside the template directory. Supported font file extensions are `.woff`, `.woff2`, `.ttf`, `.otf`, and `.eot`.
+
+## Custom helpers
+
+Custom helpers execute JavaScript from your workspace in the extension host, so they are disabled by default. Use them only in workspaces you trust.
+
+To enable helpers, run `Handlebars: Enable Unsafe Helpers` or set `handlebarsPreview.unsafeHelpers.enabled` to `true` in workspace settings. VS Code Workspace Trust must also be enabled, and helper loading is available in desktop extension hosts only.
+
+With the setting enabled, the preview looks for an adjacent helper module by default:
+
+```text
+email.handlebars
+email.handlebars.json
+email.handlebars.js
+```
+
+The helper module can export an object of helper functions:
+
+```js
+module.exports = {
+  shout(value) {
+    return String(value).toUpperCase();
+  }
+};
+```
+
+It can also export the descriptor array used by older forks:
+
+```js
+module.exports = [
+  { name: 'shout', body: value => String(value).toUpperCase() }
+];
+```
+
+For shared helpers, set `handlebarsPreview.unsafeHelpers.file` to a helper module path or URI. Relative paths resolve from the workspace folder, so `_preview_handlebars.js` loads a workspace-root file with that name. A helper module may also export a registration function that receives the isolated Handlebars instance for the current render.
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "activationEvents": [
     "onCommand:handlebars.preview",
     "onCommand:handlebars.loadPartials",
+    "onCommand:handlebars.enableUnsafeHelpers",
     "onWebviewPanel:handlebars"
   ],
   "main": "./out/extension.js",
@@ -59,6 +60,10 @@
       {
         "command": "handlebars.loadPartials",
         "title": "Handlebars: Load Partials"
+      },
+      {
+        "command": "handlebars.enableUnsafeHelpers",
+        "title": "Handlebars: Enable Unsafe Helpers"
       }
     ],
     "keybindings": [
@@ -100,6 +105,18 @@
           "type": "string",
           "default": ".json",
           "description": "Suffix appended to the template file name to find preview data."
+        },
+        "handlebarsPreview.unsafeHelpers.enabled": {
+          "type": "boolean",
+          "default": false,
+          "restricted": true,
+          "description": "Enable loading custom Handlebars helpers from workspace JavaScript. This executes workspace code in trusted desktop workspaces only."
+        },
+        "handlebarsPreview.unsafeHelpers.file": {
+          "type": "string",
+          "default": "",
+          "restricted": true,
+          "description": "Optional helper module path or URI. Relative paths resolve from the workspace folder; leave empty to use the adjacent file convention, such as email.handlebars.js."
         }
       }
     }

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -32,6 +32,14 @@ work stays small, testable, and aligned with VS Code extension behavior.
   document, or its adjacent data file changes.
 - Configured partial files are loaded by the preview panel and passed into the
   renderer by basename without requiring VS Code APIs in renderer tests.
+- Custom helper modules are disabled by default and must require explicit
+  workspace configuration or the enable command before workspace JavaScript is
+  executed.
+- Custom helper loading is allowed only in trusted desktop workspaces and only
+  from the configured helper file or the active template's adjacent
+  `template.handlebars.js`/`template.hbs.js` convention.
+- Custom helpers are registered on the isolated Handlebars instance created for
+  the current render, not on the global Handlebars singleton.
 - Preview webviews must keep scripts disabled unless a feature explicitly needs
   them and ships with matching tests and documentation.
 - Preview webviews must include a restrictive content security policy.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -22,6 +22,8 @@ Define the minimum confidence expected before changes are shipped.
   file before launching `@vscode/test-web`.
 - Rendering changes need focused tests that assert rendered output or expected
   failure behavior.
+- Custom helper changes need focused tests for supported helper export shapes,
+  helper isolation between renders, and useful escaped failure output.
 - VS Code command or panel lifecycle changes need integration tests when the
   behavior can be exercised by the extension test harness.
 - Preview command tests should assert that a `.handlebars` fixture renders with

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,8 @@ export function activate(context: ExtensionContext) {
         }),
         workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration('handlebarsPreview.dataFileSuffix')
-                || e.affectsConfiguration('handlebars.partials')) {
+                || e.affectsConfiguration('handlebars.partials')
+                || e.affectsConfiguration('handlebarsPreview.unsafeHelpers')) {
                 PreviewPanel.updateConfiguration();
             }
         }),
@@ -41,6 +42,21 @@ export function activate(context: ExtensionContext) {
             const uriStrings = uris.map((uri: Uri) => uri.toString());
             await config.update("partials", uriStrings, ConfigurationTarget.Workspace);
             PreviewPanel.update();
+        }),
+        commands.registerCommand('handlebars.enableUnsafeHelpers', async () => {
+            const choice = await window.showWarningMessage(
+                'Custom Handlebars helpers execute JavaScript from this workspace in the extension host. Enable only for workspaces you trust.',
+                { modal: true },
+                'Enable'
+            );
+
+            if (choice !== 'Enable') {
+                return;
+            }
+
+            const config = workspace.getConfiguration('handlebarsPreview.unsafeHelpers');
+            await config.update('enabled', true, ConfigurationTarget.Workspace);
+            PreviewPanel.updateConfiguration();
         })
     );
 

--- a/src/lib/PreviewPanel.ts
+++ b/src/lib/PreviewPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { HelperRegistrations, normalizeHelperModule } from "./helpers";
 import renderContent, { Partials } from "./renderContent";
 
 const textDecoder = new globalThis.TextDecoder('utf-8');
@@ -9,6 +10,14 @@ const cssImportStringPattern = /@import\s+(["'])(.*?)\1/gi;
 const cssUrlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)/gi;
 
 type WebviewResourceAdapter = Pick<vscode.Webview, 'asWebviewUri' | 'cspSource'>;
+
+type DynamicRequire = {
+	(modulePath: string): unknown;
+	resolve(modulePath: string): string;
+	cache: Record<string, unknown>;
+};
+
+declare const require: DynamicRequire | undefined;
 
 function uriEquals(left: vscode.Uri | undefined, right: vscode.Uri | undefined): boolean {
 	return left?.toString() === right?.toString();
@@ -40,6 +49,15 @@ function getDataFileSuffix(): string {
 	return configured?.trim() || '.json';
 }
 
+function getUnsafeHelpersConfiguration(): { enabled: boolean; file: string } {
+	const config = vscode.workspace.getConfiguration('handlebarsPreview.unsafeHelpers');
+
+	return {
+		enabled: config.get<boolean>('enabled') ?? false,
+		file: config.get<string>('file')?.trim() ?? ''
+	};
+}
+
 async function resolveUriOrText(uri: vscode.Uri): Promise<string> {
 	const document = vscode.workspace.textDocuments.find(e => uriEquals(e.uri, uri));
 
@@ -53,6 +71,46 @@ async function resolveUriOrText(uri: vscode.Uri): Promise<string> {
 	} catch {
 		return "";
 	}
+}
+
+async function uriExists(uri: vscode.Uri): Promise<boolean> {
+	try {
+		await vscode.workspace.fs.stat(uri);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function resolveConfiguredHelperUri(templateUri: vscode.Uri, configuredFile: string): vscode.Uri {
+	if (/^[a-z][a-z0-9+.-]*:/i.test(configuredFile)) {
+		return vscode.Uri.parse(configuredFile);
+	}
+
+	if (/^(\/|[a-zA-Z]:[\\/])/.test(configuredFile)) {
+		return vscode.Uri.file(configuredFile);
+	}
+
+	const workspaceFolder = vscode.workspace.getWorkspaceFolder(templateUri);
+	const baseUri = workspaceFolder?.uri ?? getDirectoryUri(templateUri);
+
+	return vscode.Uri.joinPath(baseUri, configuredFile);
+}
+
+export function getHelperUriForTemplate(templateUri: vscode.Uri, configuredFile = ''): vscode.Uri {
+	if (configuredFile.trim()) {
+		return resolveConfiguredHelperUri(templateUri, configuredFile.trim());
+	}
+
+	return templateUri.with({ path: `${templateUri.path}.js` });
+}
+
+function getNodeRequire(): DynamicRequire | undefined {
+	if (typeof require !== "function" || !require.cache || typeof require.resolve !== "function") {
+		return undefined;
+	}
+
+	return require;
 }
 
 export function getWebviewOptions(extensionUri: vscode.Uri, templateUri?: vscode.Uri): vscode.WebviewOptions {
@@ -283,6 +341,7 @@ export class PreviewPanel {
 	private readonly _extensionUri: vscode.Uri;
 	private _templateUri: vscode.Uri | undefined;
 	private _dataUri: vscode.Uri | undefined;
+	private _helperUri: vscode.Uri | undefined;
 	private _disposables: vscode.Disposable[] = [];
 	private _updateSequence = 0;
 
@@ -342,7 +401,7 @@ export class PreviewPanel {
 
 	public static updateConfiguration() {
 		if (PreviewPanel.currentPanel) {
-			PreviewPanel.currentPanel.refreshDataUri();
+			PreviewPanel.currentPanel.refreshRelatedUris();
 			void PreviewPanel.currentPanel.update({ useActiveEditor: false });
 		}
 	}
@@ -414,6 +473,54 @@ export class PreviewPanel {
 		return partials;
 	}
 
+	private async loadHelpers(): Promise<{ helpers?: HelperRegistrations; error?: Error }> {
+		const config = getUnsafeHelpersConfiguration();
+
+		if (!config.enabled || !this._templateUri || !this._helperUri) {
+			return {};
+		}
+
+		if (!vscode.workspace.isTrusted) {
+			return {
+				error: new Error("Custom Handlebars helpers are disabled until the workspace is trusted because loading helpers executes workspace JavaScript.")
+			};
+		}
+
+		if (this._helperUri.scheme !== 'file') {
+			return {
+				error: new Error(`Custom Handlebars helpers can only be loaded from local file paths. Got ${this._helperUri.toString()}.`)
+			};
+		}
+
+		const exists = await uriExists(this._helperUri);
+
+		if (!exists) {
+			return config.file
+				? { error: new Error(`Configured Handlebars helper file was not found: ${this._helperUri.toString()}.`) }
+				: {};
+		}
+
+		const nodeRequire = getNodeRequire();
+
+		if (!nodeRequire) {
+			return {
+				error: new Error("Custom Handlebars helpers require the desktop extension host and are not available in VS Code for the Web.")
+			};
+		}
+
+		try {
+			const modulePath = this._helperUri.fsPath;
+			const resolvedPath = nodeRequire.resolve(modulePath);
+			delete nodeRequire.cache[resolvedPath];
+
+			return { helpers: normalizeHelperModule(nodeRequire(modulePath)) };
+		} catch (error) {
+			return {
+				error: new Error(`Failed to load Handlebars helpers from ${this._helperUri.toString()}: ${error}`)
+			};
+		}
+	}
+
 	private async generateHtmlPreview(useActiveEditor: boolean): Promise<string> {
 		const activeDocument = vscode.window.activeTextEditor?.document;
 
@@ -427,8 +534,9 @@ export class PreviewPanel {
 			const templateSource = await resolveUriOrText(this._templateUri);
 			const dataSource = await resolveUriOrText(this._dataUri);
 			const partials = await this.loadPartials();
+			const helpers = await this.loadHelpers();
 
-			return renderContent(templateSource, dataSource, partials);
+			return renderContent(templateSource, dataSource, partials, helpers.helpers, helpers.error);
 		}
 
 		return `
@@ -438,17 +546,18 @@ export class PreviewPanel {
 
 	private setPreviewSource(templateUri: vscode.Uri) {
 		this._templateUri = templateUri;
-		this._dataUri = getDataUriForTemplate(templateUri, getDataFileSuffix());
 		this._panel.webview.options = getWebviewOptions(this._extensionUri, templateUri);
+		this.refreshRelatedUris();
 	}
 
-	private refreshDataUri() {
+	private refreshRelatedUris() {
 		if (this._templateUri) {
 			this._dataUri = getDataUriForTemplate(this._templateUri, getDataFileSuffix());
+			this._helperUri = getHelperUriForTemplate(this._templateUri, getUnsafeHelpersConfiguration().file);
 		}
 	}
 
 	private tracksUri(uri: vscode.Uri): boolean {
-		return uriEquals(this._templateUri, uri) || uriEquals(this._dataUri, uri);
+		return uriEquals(this._templateUri, uri) || uriEquals(this._dataUri, uri) || uriEquals(this._helperUri, uri);
 	}
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,65 @@
+import type * as Handlebars from "handlebars";
+
+export type HelperMap = Record<string, Handlebars.HelperDelegate>;
+export type HelperRegistrar = (handlebars: typeof Handlebars) => void;
+export type HelperDescriptor = {
+    name: string;
+    body: Handlebars.HelperDelegate;
+};
+export type HelperRegistrations = HelperMap | HelperDescriptor[] | HelperRegistrar;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeHelperModule(value: unknown): string {
+    if (Array.isArray(value)) {
+        return "array";
+    }
+
+    return value === null ? "null" : typeof value;
+}
+
+export function normalizeHelperModule(value: unknown): HelperRegistrations {
+    if (typeof value === "function") {
+        return value as HelperRegistrar;
+    }
+
+    if (Array.isArray(value)) {
+        value.forEach((entry, index) => {
+            if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.body !== "function") {
+                throw new Error(`Expected helper descriptor at index ${index} to include string "name" and function "body".`);
+            }
+        });
+
+        return value as HelperDescriptor[];
+    }
+
+    if (isRecord(value)) {
+        Object.entries(value).forEach(([name, helper]) => {
+            if (typeof helper !== "function") {
+                throw new Error(`Expected helper "${name}" to be a function.`);
+            }
+        });
+
+        return value as HelperMap;
+    }
+
+    throw new Error(`Expected helper module to export an object, descriptor array, or registration function. Got ${describeHelperModule(value)}.`);
+}
+
+export function registerHelpers(handlebars: typeof Handlebars, helpers: HelperRegistrations): void {
+    if (typeof helpers === "function") {
+        helpers(handlebars);
+        return;
+    }
+
+    if (Array.isArray(helpers)) {
+        helpers.forEach(({ name, body }) => handlebars.registerHelper(name, body));
+        return;
+    }
+
+    Object.entries(helpers).forEach(([name, helper]) => {
+        handlebars.registerHelper(name, helper);
+    });
+}

--- a/src/lib/renderContent.ts
+++ b/src/lib/renderContent.ts
@@ -1,5 +1,7 @@
 import * as Handlebars from "handlebars";
 
+import { HelperRegistrations, registerHelpers } from "./helpers";
+
 export type Partials = Record<string, string>;
 
 function escapeHtml(value: unknown): string {
@@ -11,18 +13,32 @@ function escapeHtml(value: unknown): string {
         .replace(/'/g, "&#39;");
 }
 
-export default (templateSource: string, dataSource?: string | null, partials: Partials = {}): string => {
+export default (
+    templateSource: string,
+    dataSource?: string | null,
+    partials: Partials = {},
+    helpers?: HelperRegistrations,
+    helperLoadError?: unknown
+): string => {
     if (!templateSource) {
         return "<p>Select document to render</p>";
     }
 
     try {
+        if (helperLoadError) {
+            throw helperLoadError;
+        }
+
         const data = JSON.parse(dataSource || "{}");
         const handlebars = Handlebars.create();
 
         Object.entries(partials).forEach(([name, content]) => {
             handlebars.registerPartial(name, content);
         });
+
+        if (helpers) {
+            registerHelpers(handlebars, helpers);
+        }
 
         const template = handlebars.compile(templateSource);
         return template(data);

--- a/src/test/suite/lib/PreviewPanel.test.ts
+++ b/src/test/suite/lib/PreviewPanel.test.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 import {
   getDataUriForTemplate,
+  getHelperUriForTemplate,
   getWebviewOptions,
   renderWebviewDocument,
   rewriteLocalFontUrls
@@ -80,5 +81,19 @@ suite("lib/PreviewPanel", () => {
     const html = renderWebviewDocument(fakeWebview, "<p>Hello</p>", templateUri);
 
     assert.match(html, /default-src 'none'; img-src vscode-webview: https: data:; font-src vscode-webview:; style-src vscode-webview: 'unsafe-inline'/);
+  });
+
+  test("derives adjacent helper uri from template uri", () => {
+    const templateUri = vscode.Uri.parse("file:///workspace/email.handlebars");
+    const helperUri = getHelperUriForTemplate(templateUri);
+
+    assert.equal(helperUri.toString(), "file:///workspace/email.handlebars.js");
+  });
+
+  test("derives configured relative helper uri from template directory without workspace", () => {
+    const templateUri = vscode.Uri.parse("file:///workspace/templates/email.handlebars");
+    const helperUri = getHelperUriForTemplate(templateUri, "_preview_handlebars.js");
+
+    assert.equal(helperUri.toString(), "file:///workspace/templates/_preview_handlebars.js");
   });
 });

--- a/src/test/suite/lib/helpers.test.ts
+++ b/src/test/suite/lib/helpers.test.ts
@@ -1,0 +1,33 @@
+import { normalizeHelperModule } from "../../../lib/helpers";
+import * as assert from "assert";
+
+suite("lib/helpers", () => {
+  test("accepts helper object exports", () => {
+    const helper = () => "ok";
+    const normalized = normalizeHelperModule({ helper });
+
+    assert.deepEqual(normalized, { helper });
+  });
+
+  test("accepts helper descriptor array exports", () => {
+    const body = () => "ok";
+    const normalized = normalizeHelperModule([{ name: "helper", body }]);
+
+    assert.deepEqual(normalized, [{ name: "helper", body }]);
+  });
+
+  test("accepts helper registration function exports", () => {
+    const register = () => undefined;
+    const normalized = normalizeHelperModule(register);
+
+    assert.equal(normalized, register);
+  });
+
+  test("rejects helper objects with non-function values", () => {
+    assert.throws(() => normalizeHelperModule({ helper: true }), /Expected helper "helper" to be a function/);
+  });
+
+  test("rejects invalid helper descriptors", () => {
+    assert.throws(() => normalizeHelperModule([{ name: "helper" }]), /Expected helper descriptor at index 0/);
+  });
+});

--- a/src/test/suite/lib/renderContent.test.ts
+++ b/src/test/suite/lib/renderContent.test.ts
@@ -37,6 +37,49 @@ suite("lib/renderContent", () => {
     assert.match(html, /partial user could not be found/);
   });
 
+  test("render with helper object", () => {
+    const html = renderContent("Super {{shout foo}}!", "{ \"foo\": \"bar\" }", {}, {
+      shout: (value: string) => value.toUpperCase(),
+    });
+
+    assert.equal(html, "Super BAR!");
+  });
+
+  test("render with helper descriptors", () => {
+    const html = renderContent("Super {{shout (ask foo)}}!", "{ \"foo\": \"bar\" }", {}, [
+      { name: "shout", body: (value: string) => value.toUpperCase() },
+      { name: "ask", body: (value: string) => `${value}?` },
+    ]);
+
+    assert.equal(html, "Super BAR?!");
+  });
+
+  test("render with helper registration function", () => {
+    const html = renderContent("Super {{shout foo}}!", "{ \"foo\": \"bar\" }", {}, handlebars => {
+      handlebars.registerHelper("shout", (value: string) => value.toUpperCase());
+    });
+
+    assert.equal(html, "Super BAR!");
+  });
+
+  test("does not leak helpers between renders", () => {
+    renderContent("Super {{shout foo}}!", "{ \"foo\": \"bar\" }", {}, {
+      shout: (value: string) => value.toUpperCase(),
+    });
+
+    const html = renderContent("Super {{shout foo}}!", "{ \"foo\": \"bar\" }");
+
+    assert.match(html, /Error occurred/);
+    assert.match(html, /Missing helper: &quot;shout&quot;/);
+  });
+
+  test("render helper load errors as escaped errors", () => {
+    const html = renderContent("Super {{foo}}!", "{ \"foo\": \"bar\" }", {}, undefined, new Error("<helper failed>"));
+
+    assert.match(html, /Error occurred/);
+    assert.match(html, /&lt;helper failed&gt;/);
+  });
+
   test("render invalid context as escaped error", () => {
     const html = renderContent("Super {{foo}}!", "{");
 


### PR DESCRIPTION
## What
Add opt-in custom Handlebars helper loading for preview rendering. Helper modules can be adjacent to the active template or configured with `handlebarsPreview.unsafeHelpers.file`, and can export helper objects, `{ name, body }[]` descriptors, or a registrar function.

## Why
Templates that depend on project-specific helpers currently fail in preview. Closes #5 while avoiding silent execution of workspace JavaScript.

## How
- Register helpers on the isolated Handlebars instance used for each render.
- Gate helper loading behind `handlebarsPreview.unsafeHelpers.enabled`, VS Code Workspace Trust, and the desktop extension host.
- Keep webview scripts disabled and execute helper code only in extension-side rendering.
- Document the helper file conventions, settings, and security tradeoff.

## Risk
- Medium: custom helpers intentionally execute workspace JavaScript after explicit opt-in.
- Existing previews remain unchanged unless helper loading is enabled.

## Security
- Reviewed workspace-code execution risk and webview execution risk.
- Helper loading is disabled by default, marked restricted, requires workspace trust, and loads only one configured or adjacent local helper file.
- Webview scripts remain disabled and CSP remains restrictive.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Docs and specs updated

## Verification
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run test:web`
- `npm run package`
