### PR TITLE
fix(preview): scope refresh watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add regression coverage for missing/invalid JSON context, escaped render errors, preview command wiring, and rendered preview output.
 - Add GitHub Actions CI for compile, lint, desktop tests, web tests, audit, and package validation.
 - Add `Handlebars: Load Partials` for workspace-configured partial files.
+- Refresh previews when configured partial files change, without watching the
+  entire workspace.
 - Add opt-in custom helper loading for trusted desktop workspaces through
   `handlebarsPreview.unsafeHelpers.*` settings.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 - Use the keybinding `ctrl+k h`.
 - To run from the command palette, use `ctrl+shift+p` and type `Handlebars: Open Preview`.
 - By default, preview data is read from the template file name plus `.json`, such as `email.handlebars.json`.
-- To register partials for preview rendering, run `Handlebars: Load Partials` and select one or more partial files. Each partial is available by its file basename.
+- To register partials for preview rendering, run `Handlebars: Load Partials` and select one or more partial files. Each partial is available by its file basename, and edits to selected partials refresh the active preview.
 - Local font files referenced from inline styles, `<style>` blocks, local stylesheet links, or local CSS imports can load when they are inside the template directory. Supported font file extensions are `.woff`, `.woff2`, `.ttf`, `.otf`, and `.eot`.
 
 ## Custom helpers

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -29,7 +29,13 @@ work stays small, testable, and aligned with VS Code extension behavior.
   JSON context; missing or invalid context should fail predictably and be
   covered by tests.
 - Preview updates should refresh when the active template, its open text
-  document, or its adjacent data file changes.
+  document, its adjacent data file, its helper file, or configured partial
+  files change.
+- Preview refreshes from file and text-document changes should be coalesced so
+  rapid edits do not start redundant renders.
+- File watching should stay scoped to directories for the active preview's
+  template, data, helper, and partial resources instead of watching the entire
+  workspace.
 - Configured partial files are loaded by the preview panel and passed into the
   renderer by basename without requiring VS Code APIs in renderer tests.
 - Custom helper modules are disabled by default and must require explicit

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -28,6 +28,9 @@ Define the minimum confidence expected before changes are shipped.
   behavior can be exercised by the extension test harness.
 - Preview command tests should assert that a `.handlebars` fixture renders with
   its adjacent JSON data, not only that the webview opens.
+- Partial preview tests should assert that changing a configured partial
+  refreshes the active template preview without switching the preview source to
+  the partial document.
 - Bug fixes should include regression tests when practical.
 - CI must run compile, lint, desktop tests, web tests, audit, and package
   validation for pull requests and pushes.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,13 +6,7 @@ import {
 import { PreviewPanel } from './lib/PreviewPanel';
 
 export function activate(context: ExtensionContext) {
-    const watcher = workspace.createFileSystemWatcher('**/*');
-
     context.subscriptions.push(
-        watcher,
-        watcher.onDidChange(uri => PreviewPanel.refreshForUri(uri)),
-        watcher.onDidCreate(uri => PreviewPanel.refreshForUri(uri)),
-        watcher.onDidDelete(uri => PreviewPanel.refreshForUri(uri)),
         window.onDidChangeActiveTextEditor(() => {
             PreviewPanel.updateFromActiveEditor();
         }),

--- a/src/lib/PreviewPanel.ts
+++ b/src/lib/PreviewPanel.ts
@@ -8,6 +8,7 @@ const supportedFontExtensions = new Set(['.woff', '.woff2', '.ttf', '.otf', '.eo
 const supportedStylesheetExtensions = new Set(['.css']);
 const cssImportStringPattern = /@import\s+(["'])(.*?)\1/gi;
 const cssUrlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)/gi;
+const refreshDebounceMs = 75;
 
 type WebviewResourceAdapter = Pick<vscode.Webview, 'asWebviewUri' | 'cspSource'>;
 
@@ -25,6 +26,13 @@ function uriEquals(left: vscode.Uri | undefined, right: vscode.Uri | undefined):
 
 function uriFromConfigurationValue(value: string): vscode.Uri {
 	return /^[a-z][a-z0-9+.-]*:/i.test(value) ? vscode.Uri.parse(value) : vscode.Uri.file(value);
+}
+
+export function getPartialUrisFromConfigurationValues(values: readonly string[]): vscode.Uri[] {
+	return values
+		.map(value => value.trim())
+		.filter(Boolean)
+		.map(uriFromConfigurationValue);
 }
 
 function basenameWithoutExtension(uri: vscode.Uri): string {
@@ -56,6 +64,11 @@ function getUnsafeHelpersConfiguration(): { enabled: boolean; file: string } {
 		enabled: config.get<boolean>('enabled') ?? false,
 		file: config.get<string>('file')?.trim() ?? ''
 	};
+}
+
+function getConfiguredPartialUris(): vscode.Uri[] {
+	const config = vscode.workspace.getConfiguration("handlebars");
+	return getPartialUrisFromConfigurationValues(config.get<string[]>("partials") ?? []);
 }
 
 async function resolveUriOrText(uri: vscode.Uri): Promise<string> {
@@ -124,6 +137,27 @@ export function getWebviewOptions(extensionUri: vscode.Uri, templateUri?: vscode
 		enableScripts: false,
 		localResourceRoots
 	};
+}
+
+export function getWatchDirectoriesForUris(uris: readonly vscode.Uri[]): vscode.Uri[] {
+	const seen = new Set<string>();
+	const directories: vscode.Uri[] = [];
+
+	uris.forEach(uri => {
+		if (uri.scheme === 'untitled') {
+			return;
+		}
+
+		const directory = getDirectoryUri(uri);
+		const key = directory.toString();
+
+		if (!seen.has(key)) {
+			seen.add(key);
+			directories.push(directory);
+		}
+	});
+
+	return directories;
 }
 
 function splitResourceReference(value: string): { path: string; query: string; fragment: string } {
@@ -342,7 +376,10 @@ export class PreviewPanel {
 	private _templateUri: vscode.Uri | undefined;
 	private _dataUri: vscode.Uri | undefined;
 	private _helperUri: vscode.Uri | undefined;
+	private _partialUris: vscode.Uri[] = [];
 	private _disposables: vscode.Disposable[] = [];
+	private _fileWatcherDisposables: vscode.Disposable[] = [];
+	private _refreshTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
 	private _updateSequence = 0;
 
 	public static activate(context: vscode.ExtensionContext) {
@@ -383,7 +420,7 @@ export class PreviewPanel {
 
 	public static update() {
 		if (PreviewPanel.currentPanel) {
-			void PreviewPanel.currentPanel.update({ useActiveEditor: false });
+			PreviewPanel.currentPanel.scheduleUpdate({ useActiveEditor: false });
 		}
 	}
 
@@ -395,7 +432,7 @@ export class PreviewPanel {
 
 	public static refreshForUri(uri: vscode.Uri) {
 		if (PreviewPanel.currentPanel?.tracksUri(uri)) {
-			void PreviewPanel.currentPanel.update({ useActiveEditor: false });
+			PreviewPanel.currentPanel.scheduleUpdate({ useActiveEditor: false });
 		}
 	}
 
@@ -432,6 +469,8 @@ export class PreviewPanel {
 
 	public dispose() {
 		PreviewPanel.currentPanel = undefined;
+		this.clearScheduledUpdate();
+		this.disposeFileWatchers();
 
 		// Clean up our resources
 		this._panel.dispose();
@@ -444,7 +483,23 @@ export class PreviewPanel {
 		}
 	}
 
+	private scheduleUpdate(options: { useActiveEditor: boolean }) {
+		this.clearScheduledUpdate();
+		this._refreshTimer = globalThis.setTimeout(() => {
+			this._refreshTimer = undefined;
+			void this.update(options);
+		}, refreshDebounceMs);
+	}
+
+	private clearScheduledUpdate() {
+		if (this._refreshTimer !== undefined) {
+			globalThis.clearTimeout(this._refreshTimer);
+			this._refreshTimer = undefined;
+		}
+	}
+
 	private async update(options: { useActiveEditor: boolean }): Promise<string> {
+		this.clearScheduledUpdate();
 		const updateSequence = ++this._updateSequence;
 		const body = await this.generateHtmlPreview(options.useActiveEditor);
 		const html = renderWebviewDocument(this._panel.webview, body, this._templateUri);
@@ -457,12 +512,9 @@ export class PreviewPanel {
 	}
 
 	private async loadPartials(): Promise<Partials> {
-		const config = vscode.workspace.getConfiguration("handlebars");
-		const partialValues = config.get<string[]>("partials") ?? [];
 		const partials: Partials = {};
 
-		await Promise.all(partialValues.map(async value => {
-			const uri = uriFromConfigurationValue(value);
+		await Promise.all(this._partialUris.map(async uri => {
 			const partialName = basenameWithoutExtension(uri);
 
 			if (partialName) {
@@ -554,10 +606,45 @@ export class PreviewPanel {
 		if (this._templateUri) {
 			this._dataUri = getDataUriForTemplate(this._templateUri, getDataFileSuffix());
 			this._helperUri = getHelperUriForTemplate(this._templateUri, getUnsafeHelpersConfiguration().file);
+			this._partialUris = getConfiguredPartialUris();
+			this.updateFileWatchers();
 		}
 	}
 
 	private tracksUri(uri: vscode.Uri): boolean {
-		return uriEquals(this._templateUri, uri) || uriEquals(this._dataUri, uri) || uriEquals(this._helperUri, uri);
+		return uriEquals(this._templateUri, uri)
+			|| uriEquals(this._dataUri, uri)
+			|| uriEquals(this._helperUri, uri)
+			|| this._partialUris.some(partialUri => uriEquals(partialUri, uri));
+	}
+
+	private getTrackedUris(): vscode.Uri[] {
+		return [
+			this._templateUri,
+			this._dataUri,
+			this._helperUri,
+			...this._partialUris
+		].filter((uri): uri is vscode.Uri => uri !== undefined);
+	}
+
+	private disposeFileWatchers() {
+		while (this._fileWatcherDisposables.length) {
+			const disposable = this._fileWatcherDisposables.pop();
+			disposable?.dispose();
+		}
+	}
+
+	private updateFileWatchers() {
+		this.disposeFileWatchers();
+
+		getWatchDirectoriesForUris(this.getTrackedUris()).forEach(directory => {
+			const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(directory, '*'));
+			this._fileWatcherDisposables.push(
+				watcher,
+				watcher.onDidChange(uri => PreviewPanel.refreshForUri(uri)),
+				watcher.onDidCreate(uri => PreviewPanel.refreshForUri(uri)),
+				watcher.onDidDelete(uri => PreviewPanel.refreshForUri(uri))
+			);
+		});
 	}
 }

--- a/src/test/suite/assertions.ts
+++ b/src/test/suite/assertions.ts
@@ -4,6 +4,12 @@ export function equal(actual: unknown, expected: unknown, message?: string): voi
 	}
 }
 
+export function deepEqual(actual: unknown, expected: unknown, message?: string): void {
+	if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+		throw new Error(message ?? `Expected ${JSON.stringify(actual)} to deep equal ${JSON.stringify(expected)}`);
+	}
+}
+
 export function ok(value: unknown, message?: string): asserts value {
 	if (!value) {
 		throw new Error(message ?? `Expected ${String(value)} to be truthy`);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,6 +3,20 @@ import * as vscode from 'vscode';
 import * as extension from "../../extension";
 import * as assert from "./assertions";
 
+function basenameWithoutExtension(uri: vscode.Uri): string {
+	const basename = uri.path.split('/').pop() ?? '';
+	return basename.replace(/\.[^/.]+$/, '');
+}
+
+function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
+	const lastLine = document.lineAt(document.lineCount - 1);
+	return new vscode.Range(0, 0, lastLine.lineNumber, lastLine.range.end.character);
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise(resolve => globalThis.setTimeout(resolve, ms));
+}
+
 suite('extension', () => {
 	test('activation', () => {
 		assert.ok(extension.activate);
@@ -58,5 +72,45 @@ suite('extension', () => {
 		assert.match(html, /font-src/);
 		assert.match(html, /preview-local\.woff2/);
 		assert.doesNotMatch(html, /url\("\.\/fonts\/preview-local\.woff2"\)/);
+	});
+
+	test('refreshes preview when a configured partial document changes', async () => {
+		const previousPartials = vscode.workspace.getConfiguration("handlebars").get<string[]>("partials");
+		const partialDocument = await vscode.workspace.openTextDocument({
+			language: 'handlebars',
+			content: 'First'
+		});
+		const partialName = basenameWithoutExtension(partialDocument.uri);
+		const templateDocument = await vscode.workspace.openTextDocument({
+			language: 'handlebars',
+			content: `Hello {{> ${partialName}}}!`
+		});
+
+		try {
+			await vscode.workspace
+				.getConfiguration("handlebars")
+				.update("partials", [partialDocument.uri.toString()], vscode.ConfigurationTarget.Global);
+
+			await vscode.window.showTextDocument(templateDocument);
+			const initialHtml = await vscode.commands.executeCommand<string>('handlebars.preview');
+
+			assert.ok(initialHtml);
+			assert.match(initialHtml, /Hello First!/);
+
+			await vscode.window.showTextDocument(partialDocument);
+			const edit = new vscode.WorkspaceEdit();
+			edit.replace(partialDocument.uri, fullDocumentRange(partialDocument), "Second");
+			assert.ok(await vscode.workspace.applyEdit(edit));
+
+			await delay(150);
+			const refreshedHtml = await vscode.commands.executeCommand<string>('handlebars.preview');
+
+			assert.ok(refreshedHtml);
+			assert.match(refreshedHtml, /Hello Second!/);
+		} finally {
+			await vscode.workspace
+				.getConfiguration("handlebars")
+				.update("partials", previousPartials, vscode.ConfigurationTarget.Global);
+		}
 	});
 });

--- a/src/test/suite/lib/PreviewPanel.test.ts
+++ b/src/test/suite/lib/PreviewPanel.test.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 import {
   getDataUriForTemplate,
   getHelperUriForTemplate,
+  getPartialUrisFromConfigurationValues,
+  getWatchDirectoriesForUris,
   getWebviewOptions,
   renderWebviewDocument,
   rewriteLocalFontUrls
@@ -95,5 +97,33 @@ suite("lib/PreviewPanel", () => {
     const helperUri = getHelperUriForTemplate(templateUri, "_preview_handlebars.js");
 
     assert.equal(helperUri.toString(), "file:///workspace/templates/_preview_handlebars.js");
+  });
+
+  test("normalizes configured partial uris and skips empty values", () => {
+    const partialUris = getPartialUrisFromConfigurationValues([
+      "",
+      "  file:///workspace/partials/card.handlebars  ",
+      "/workspace/partials/footer.handlebars"
+    ]);
+
+    assert.deepEqual(partialUris.map(uri => uri.toString()), [
+      "file:///workspace/partials/card.handlebars",
+      "file:///workspace/partials/footer.handlebars"
+    ]);
+  });
+
+  test("watches only directories for tracked non-untitled resources", () => {
+    const directories = getWatchDirectoriesForUris([
+      vscode.Uri.file("/workspace/templates/email.handlebars"),
+      vscode.Uri.file("/workspace/templates/email.handlebars.json"),
+      vscode.Uri.file("/workspace/partials/card.handlebars"),
+      vscode.Uri.file("/workspace/partials/footer.handlebars"),
+      vscode.Uri.parse("untitled:Untitled-1")
+    ]);
+
+    assert.deepEqual(directories.map(uri => uri.toString()), [
+      "file:///workspace/templates",
+      "file:///workspace/partials"
+    ]);
   });
 });


### PR DESCRIPTION
## What
- Replace the workspace-wide `**/*` watcher with preview-scoped directory watchers for the active template, adjacent data, helper, and configured partial resources.
- Track configured partial URIs so partial edits refresh the active template preview instead of switching preview source.
- Debounce refresh-triggered renders to coalesce rapid file/text changes.
- Update tests, README, changelog, and specs for the new partial-refresh behavior.

## Why
The preview was paying a workspace-wide watcher cost and still missed configured partial file changes. Rapid edits could also start redundant render work even though stale results were discarded.

## How
`PreviewPanel` now owns the tracked URI set, derives narrow watch directories from it, and schedules refresh updates through a short debounce while keeping command-triggered renders immediate.

## Risk
- Low to medium: preview lifecycle and file watching changed.
- Main risk is a missed refresh for unusual filesystem providers; desktop and web command-path tests cover template/data/local-font rendering and partial edit refreshes.

## Security
- Security review performed for webview/resource handling.
- Webview scripts remain disabled, CSP remains restrictive, local resource roots are unchanged, and custom helper execution remains gated by trusted workspace plus explicit unsafe settings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Verification:
- `npm run compile`
- `npm run lint`
- `npm test` - 31 passing
- `npm run test:web` - 26 passing
- `npm audit --audit-level=moderate` - 0 vulnerabilities
- `npm run package`
