### PR TITLE
fix(preview): add built-in compatibility helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add opt-in custom helper loading for trusted desktop workspaces through
   `handlebarsPreview.unsafeHelpers.*` settings.
 - Add `handlebarsPreview.backgroundColor` to override the preview webview background.
+- Add built-in `compare`, `eq`, and safe identity `eval` compatibility helpers.
 
 ## [1.3.1] - 2022-07-19
 - Extension now contributes to Explorer context menu

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 - Contributes `.handlebars` and `.hbs` language recognition.
 - Support for partials selected from the command palette.
 - Support for local `@font-face` fonts referenced from the template directory.
+- Built-in `compare`, `eq`, and `eval` compatibility helpers.
 - Optional custom helper support from trusted workspace JavaScript.
 - Preview webviews run with scripts disabled and a restrictive content security policy.
 
@@ -29,6 +30,15 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 - Set `handlebarsPreview.backgroundColor` to a CSS color such as `#ffffff`, `white`, or `rgb(255, 255, 255)` to override the preview background.
 - To register partials for preview rendering, run `Handlebars: Load Partials` and select one or more partial files. Each partial is available by its file basename.
 - Local font files referenced from inline styles, `<style>` blocks, local stylesheet links, or local CSS imports can load when they are inside the template directory. Supported font file extensions are `.woff`, `.woff2`, `.ttf`, `.otf`, and `.eot`.
+
+## Built-in helpers
+
+The preview registers a small set of compatibility helpers by default:
+
+- `{{#compare left right}}...{{else}}...{{/compare}}` compares with loose equality.
+- `{{#compare left ">" right}}...{{/compare}}` also supports `==`, `===`, `!=`, `!==`, `<`, `>`, `<=`, `>=`, and `typeof`.
+- `{{eq left right}}` returns a boolean and can be used as a block helper or subexpression.
+- `{{eval value}}` returns the already-evaluated Handlebars value. It does not execute JavaScript.
 
 ## Custom helpers
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -31,6 +31,8 @@ work stays small, testable, and aligned with VS Code extension behavior.
 - Webview output should be generated from compiled Handlebars and the matching
   JSON context; missing or invalid context should fail predictably and be
   covered by tests.
+- The renderer registers built-in `compare`, `eq`, and safe identity `eval`
+  helpers on each isolated Handlebars instance for template compatibility.
 - Preview updates should refresh when the active template, its open text
   document, or its adjacent data file changes.
 - Configured partial files are loaded by the preview panel and passed into the

--- a/src/lib/builtinHelpers.ts
+++ b/src/lib/builtinHelpers.ts
@@ -1,0 +1,96 @@
+import type * as Handlebars from "handlebars";
+
+const comparisonOperators = new Set(["==", "===", "!=", "!==", "<", ">", "<=", ">=", "typeof"]);
+
+function isNumeric(value: unknown): boolean {
+    return (typeof value === "number" && Number.isFinite(value))
+        || (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value)));
+}
+
+function valuesEqual(left: unknown, right: unknown, strict: boolean): boolean {
+    if (Object.is(left, right)) {
+        return true;
+    }
+
+    if (strict) {
+        return false;
+    }
+
+    if ((left === null && right === undefined) || (left === undefined && right === null)) {
+        return true;
+    }
+
+    if (isNumeric(left) && isNumeric(right)) {
+        return Number(left) === Number(right);
+    }
+
+    return String(left) === String(right);
+}
+
+function compareValues(left: unknown, operator: string, right: unknown): boolean {
+    switch (operator) {
+        case "==":
+            return valuesEqual(left, right, false);
+        case "===":
+            return valuesEqual(left, right, true);
+        case "!=":
+            return !valuesEqual(left, right, false);
+        case "!==":
+            return !valuesEqual(left, right, true);
+        case "<":
+            return isNumeric(left) && isNumeric(right) ? Number(left) < Number(right) : String(left) < String(right);
+        case ">":
+            return isNumeric(left) && isNumeric(right) ? Number(left) > Number(right) : String(left) > String(right);
+        case "<=":
+            return isNumeric(left) && isNumeric(right) ? Number(left) <= Number(right) : String(left) <= String(right);
+        case ">=":
+            return isNumeric(left) && isNumeric(right) ? Number(left) >= Number(right) : String(left) >= String(right);
+        case "typeof":
+            return typeof left === right;
+        default:
+            throw new Error(`Unsupported compare operator "${operator}".`);
+    }
+}
+
+function renderBooleanResult(thisArg: unknown, result: boolean, options: unknown): unknown {
+    const helperOptions = options as Partial<Handlebars.HelperOptions>;
+
+    if (typeof helperOptions.fn === "function" && typeof helperOptions.inverse === "function") {
+        return result ? helperOptions.fn(thisArg) : helperOptions.inverse(thisArg);
+    }
+
+    return result;
+}
+
+function getOperatorFromOptions(options: unknown): string | undefined {
+    const helperOptions = options as Partial<Handlebars.HelperOptions>;
+    const operator = helperOptions.hash?.operator;
+
+    return typeof operator === "string" ? operator : undefined;
+}
+
+export function registerBuiltinHelpers(handlebars: typeof Handlebars): void {
+    handlebars.registerHelper("eq", function eqHelper(this: unknown, left: unknown, right: unknown, options: unknown): unknown {
+        return renderBooleanResult(this, valuesEqual(left, right, false), options);
+    });
+
+    handlebars.registerHelper("compare", function compareHelper(this: unknown, ...args: unknown[]): unknown {
+        const options = args.at(-1);
+        const values = args.slice(0, -1);
+        let left: unknown;
+        let right: unknown;
+        let operator = getOperatorFromOptions(options) ?? "==";
+
+        if (values.length === 3 && typeof values[1] === "string" && comparisonOperators.has(values[1])) {
+            [left, operator, right] = values;
+        } else if (values.length === 2) {
+            [left, right] = values;
+        } else {
+            throw new Error("Helper \"compare\" needs two values and an optional operator.");
+        }
+
+        return renderBooleanResult(this, compareValues(left, operator, right), options);
+    });
+
+    handlebars.registerHelper("eval", (value: unknown) => value);
+}

--- a/src/lib/renderContent.ts
+++ b/src/lib/renderContent.ts
@@ -1,5 +1,6 @@
 import * as Handlebars from "handlebars";
 
+import { registerBuiltinHelpers } from "./builtinHelpers";
 import { HelperRegistrations, registerHelpers } from "./helpers";
 
 export type Partials = Record<string, string>;
@@ -31,6 +32,7 @@ export default (
 
         const data = JSON.parse(dataSource || "{}");
         const handlebars = Handlebars.create();
+        registerBuiltinHelpers(handlebars);
 
         Object.entries(partials).forEach(([name, content]) => {
             handlebars.registerPartial(name, content);

--- a/src/test/examples/simple.handlebars
+++ b/src/test/examples/simple.handlebars
@@ -1,1 +1,2 @@
 Super {{foo}}!
+{{#compare foo "bar"}}Comparison helper ok!{{/compare}}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -40,6 +40,7 @@ suite('extension', () => {
 		assert.ok(html);
 		assert.doesNotMatch(html, /Super \{\{foo\}\}!/);
 		assert.match(html, /Super bar!/);
+		assert.match(html, /Comparison helper ok!/);
 	});
 
 	test('renders local font references through the preview command', async () => {

--- a/src/test/suite/lib/renderContent.test.ts
+++ b/src/test/suite/lib/renderContent.test.ts
@@ -26,6 +26,17 @@ suite("lib/renderContent", () => {
     assert.equal(html, "Hello <b>Ada</b>!");
   });
 
+  test("render with built-in comparison helpers", () => {
+    const html = renderContent([
+      "{{#compare count 3}}same{{else}}different{{/compare}}",
+      "{{#compare count \">\" min}}above{{else}}below{{/compare}}",
+      "{{#if (eq status \"active\")}}active{{else}}inactive{{/if}}",
+      "{{eval status}}",
+    ].join(" "), "{ \"count\": \"3\", \"min\": 2, \"status\": \"active\" }");
+
+    assert.equal(html, "same above active active");
+  });
+
   test("does not leak partials between renders", () => {
     renderContent("Hello {{> user}}!", "{ \"name\": \"Ada\" }", {
       user: "<b>{{name}}</b>",


### PR DESCRIPTION
## What
Add built-in `compare`, `eq`, and safe identity `eval` compatibility helpers to the isolated Handlebars renderer.

## Why
Templates using these common helper names currently fail in preview with missing-helper render errors.

## How
- Register built-in helpers on each render-local Handlebars instance before custom helpers.
- Keep `eval` as an identity helper only, so it does not execute JavaScript.
- Add renderer regression coverage and command-path coverage through the preview fixture.
- Document the helpers in README, CHANGELOG, and architecture spec.

## Risk
Low. The helpers are isolated per render, and custom workspace helpers are still registered after built-ins so users can override these names.

## Security
Reviewed template-input and webview risks. The new `eval` helper intentionally does not evaluate JavaScript or broaden filesystem/webview access.

## Verification
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run test:web`
- `npm run package`

## Follow-ups
No follow-ups.
