### PR TITLE
ci: update actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 26
           cache: npm


### PR DESCRIPTION
## What
Update the CI workflow to use `actions/checkout@v5` and `actions/setup-node@v5`.

## Why
GitHub Actions emitted a non-blocking Node.js 20 deprecation annotation for the v4 actions. The v5 releases declare the Node 24 action runtime while keeping the existing workflow behavior.

## Risk
Low. This only changes workflow action versions and keeps the project Node version and npm cache settings unchanged.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run package`

## Security
No security-relevant extension runtime changes. The change is limited to CI action metadata/runtime versions.
