### PR TITLE
feat(preview): add source preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   `handlebarsPreview.unsafeHelpers.*` settings.
 - Add `handlebarsPreview.backgroundColor` to override the preview webview background.
 - Add built-in `compare`, `eq`, and safe identity `eval` compatibility helpers.
+- Add `Handlebars: Open Source Preview` to inspect escaped generated output and preserve whitespace for non-HTML text/code rendering.
 
 ## [1.3.1] - 2022-07-19
 - Extension now contributes to Explorer context menu

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 ## Features
 
 - Live preview for Handlebars templates. Preview updates as you type.
+- Source preview for generated markup or text output with whitespace preserved.
 - Support for fake data. Add file `yourtemplate.handlebars.json` to be a context of the template.
 - Configurable preview data suffix through `handlebarsPreview.dataFileSuffix`.
 - Configurable preview background color through `handlebarsPreview.backgroundColor`.
@@ -26,6 +27,7 @@ Runs in VS Code desktop, remote workspaces, and VS Code for the Web.
 
 - Use the keybinding `ctrl+k h`.
 - To run from the command palette, use `ctrl+shift+p` and type `Handlebars: Open Preview`.
+- To inspect the generated HTML/source or preserve non-HTML text formatting, run `Handlebars: Open Source Preview`.
 - By default, preview data is read from the template file name plus `.json`, such as `email.handlebars.json`.
 - To register partials for preview rendering, run `Handlebars: Load Partials` and select one or more partial files. Each partial is available by its file basename, and edits to selected partials refresh the active preview.
 - Set `handlebarsPreview.backgroundColor` to a CSS color such as `#ffffff`, `white`, or `rgb(255, 255, 255)` to override the preview background.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "activationEvents": [
     "onCommand:handlebars.preview",
+    "onCommand:handlebars.previewSource",
     "onCommand:handlebars.loadPartials",
     "onCommand:handlebars.enableUnsafeHelpers",
     "onWebviewPanel:handlebars"
@@ -58,6 +59,10 @@
         "title": "Handlebars: Open Preview"
       },
       {
+        "command": "handlebars.previewSource",
+        "title": "Handlebars: Open Source Preview"
+      },
+      {
         "command": "handlebars.loadPartials",
         "title": "Handlebars: Load Partials"
       },
@@ -79,11 +84,21 @@
           "command": "handlebars.preview",
           "when": "resourceLangId == handlebars",
           "group": "Handlebars"
+        },
+        {
+          "command": "handlebars.previewSource",
+          "when": "resourceLangId == handlebars",
+          "group": "Handlebars"
         }
       ],
       "editor/title/context": [
         {
           "command": "handlebars.preview",
+          "when": "resourceLangId == handlebars",
+          "group": "Handlebars"
+        },
+        {
+          "command": "handlebars.previewSource",
           "when": "resourceLangId == handlebars",
           "group": "Handlebars"
         }

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -12,6 +12,8 @@ work stays small, testable, and aligned with VS Code extension behavior.
 ## Requirements
 
 - Extension activation remains command-driven through `handlebars.preview`.
+- Source preview activation remains command-driven through
+  `handlebars.previewSource`.
 - The extension remains web-compatible and exposes a `browser` entry in
   `package.json`.
 - Command wiring and VS Code API integration belong near `src/extension.ts`.
@@ -33,6 +35,9 @@ work stays small, testable, and aligned with VS Code extension behavior.
   covered by tests.
 - The renderer registers built-in `compare`, `eq`, and safe identity `eval`
   helpers on each isolated Handlebars instance for template compatibility.
+- Visual preview mode inserts generated output as HTML; source preview mode
+  escapes generated output and presents it in a whitespace-preserving code
+  surface for inspecting markup or non-HTML text.
 - Preview updates should refresh when the active template, its open text
   document, its adjacent data file, its helper file, or configured partial
   files change.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -31,6 +31,8 @@ Define the minimum confidence expected before changes are shipped.
 - Partial preview tests should assert that changing a configured partial
   refreshes the active template preview without switching the preview source to
   the partial document.
+- Source preview tests should assert that generated output is escaped and
+  presented in a whitespace-preserving surface.
 - Bug fixes should include regression tests when practical.
 - CI must run compile, lint, desktop tests, web tests, audit, and package
   validation for pull requests and pushes.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ export function activate(context: ExtensionContext) {
             PreviewPanel.refreshForUri(e.document.uri);
         }),
         commands.registerCommand('handlebars.preview', () => PreviewPanel.createOrShow(context.extensionUri)),
+        commands.registerCommand('handlebars.previewSource', () => PreviewPanel.createOrShow(context.extensionUri, 'source')),
         commands.registerCommand('handlebars.loadPartials', async () => {
             const uris = await window.showOpenDialog({
                 canSelectMany: true,

--- a/src/lib/PreviewPanel.ts
+++ b/src/lib/PreviewPanel.ts
@@ -9,6 +9,12 @@ const supportedStylesheetExtensions = new Set(['.css']);
 const cssImportStringPattern = /@import\s+(["'])(.*?)\1/gi;
 const cssUrlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)/gi;
 const refreshDebounceMs = 75;
+export type PreviewMode = 'visual' | 'source';
+
+const previewTitles: Record<PreviewMode, string> = {
+	visual: 'Handlebars HTML Preview',
+	source: 'Handlebars Source Preview'
+};
 
 type WebviewResourceAdapter = Pick<vscode.Webview, 'asWebviewUri' | 'cspSource'>;
 
@@ -377,11 +383,37 @@ export function rewriteLocalFontUrls(
 		});
 }
 
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function getPreviewTitle(mode: PreviewMode): string {
+	return previewTitles[mode];
+}
+
+function getPreviewModeFromTitle(title: string): PreviewMode {
+	return title === previewTitles.source ? 'source' : 'visual';
+}
+
+export function renderPreviewBody(renderedOutput: string, mode: PreviewMode): string {
+	if (mode === 'visual') {
+		return renderedOutput;
+	}
+
+	return `<main class="source-preview" aria-label="Generated source preview"><pre><code>${escapeHtml(renderedOutput)}</code></pre></main>`;
+}
+
 export function renderWebviewDocument(
 	webview: WebviewResourceAdapter,
 	body: string,
 	templateUri?: vscode.Uri,
-	backgroundColor?: string
+	backgroundColor?: string,
+	mode: PreviewMode = 'visual'
 ): string {
 	const renderedBody = templateUri ? rewriteLocalFontUrls(body, templateUri, webview) : body;
 	const contentSecurityPolicy = [
@@ -392,6 +424,28 @@ export function renderWebviewDocument(
 	].join("; ");
 	const safeBackgroundColor = sanitizeBackgroundColor(backgroundColor);
 	const bodyAttributes = safeBackgroundColor ? ` style="background-color: ${safeBackgroundColor};"` : "";
+	const sourcePreviewStyle = mode === 'source' ? `
+	<style>
+		.source-preview {
+			box-sizing: border-box;
+			min-height: 100vh;
+			padding: 1rem;
+			color: var(--vscode-editor-foreground);
+			background: var(--vscode-editor-background);
+		}
+
+		.source-preview pre {
+			margin: 0;
+			white-space: pre-wrap;
+			overflow-wrap: anywhere;
+		}
+
+		.source-preview code {
+			font-family: var(--vscode-editor-font-family, monospace);
+			font-size: var(--vscode-editor-font-size, 13px);
+			line-height: 1.5;
+		}
+	</style>` : '';
 
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -399,7 +453,8 @@ export function renderWebviewDocument(
 	<meta charset="UTF-8">
 	<meta http-equiv="Content-Security-Policy" content="${contentSecurityPolicy}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Handlebars HTML Preview</title>
+	<title>${getPreviewTitle(mode)}</title>
+	${sourcePreviewStyle}
 </head>
 <body${bodyAttributes}>
 ${renderedBody}
@@ -422,6 +477,7 @@ export class PreviewPanel {
 	private _fileWatcherDisposables: vscode.Disposable[] = [];
 	private _refreshTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
 	private _updateSequence = 0;
+	private _mode: PreviewMode;
 
 	public static activate(context: vscode.ExtensionContext) {
 		if (vscode.window.registerWebviewPanelSerializer) {
@@ -430,15 +486,16 @@ export class PreviewPanel {
 				async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel) {
 					// Reset the webview options so we use latest uri for `localResourceRoots`.
 					webviewPanel.webview.options = getWebviewOptions(context.extensionUri);
-					PreviewPanel.revive(webviewPanel, context.extensionUri);
+					PreviewPanel.revive(webviewPanel, context.extensionUri, getPreviewModeFromTitle(webviewPanel.title));
 				}
 			});
 		}
 	}
 
-	public static async createOrShow(extensionUri: vscode.Uri): Promise<string | undefined> {
+	public static async createOrShow(extensionUri: vscode.Uri, mode: PreviewMode = 'visual'): Promise<string | undefined> {
 		// If we already have a panel, show it.
 		if (PreviewPanel.currentPanel) {
+			PreviewPanel.currentPanel.setMode(mode);
 			PreviewPanel.currentPanel._panel.reveal(vscode.ViewColumn.Two);
 			return PreviewPanel.currentPanel.update({ useActiveEditor: true });
 		}
@@ -446,17 +503,17 @@ export class PreviewPanel {
 		// Otherwise, create a new panel.
 		const panel = vscode.window.createWebviewPanel(
 			PreviewPanel.viewType,
-			'Handlebars HTML Preview',
+			getPreviewTitle(mode),
 			vscode.ViewColumn.Two,
 			getWebviewOptions(extensionUri),
 		);
 
-		PreviewPanel.currentPanel = new PreviewPanel(panel, extensionUri);
+		PreviewPanel.currentPanel = new PreviewPanel(panel, extensionUri, mode);
 		return PreviewPanel.currentPanel.update({ useActiveEditor: true });
 	}
 
-	public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
-		PreviewPanel.currentPanel = new PreviewPanel(panel, extensionUri);
+	public static revive(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, mode: PreviewMode = 'visual') {
+		PreviewPanel.currentPanel = new PreviewPanel(panel, extensionUri, mode);
 	}
 
 	public static update() {
@@ -484,9 +541,11 @@ export class PreviewPanel {
 		}
 	}
 
-	private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+	private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, mode: PreviewMode) {
 		this._panel = panel;
 		this._extensionUri = extensionUri;
+		this._mode = mode;
+		this._panel.title = getPreviewTitle(mode);
 
 		// Set the webview's initial html content
 		void this.update({ useActiveEditor: true });
@@ -542,8 +601,9 @@ export class PreviewPanel {
 	private async update(options: { useActiveEditor: boolean }): Promise<string> {
 		this.clearScheduledUpdate();
 		const updateSequence = ++this._updateSequence;
-		const body = await this.generateHtmlPreview(options.useActiveEditor);
-		const html = renderWebviewDocument(this._panel.webview, body, this._templateUri, getBackgroundColor());
+		const renderedOutput = await this.generateHtmlPreview(options.useActiveEditor);
+		const body = renderPreviewBody(renderedOutput, this._mode);
+		const html = renderWebviewDocument(this._panel.webview, body, this._templateUri, getBackgroundColor(), this._mode);
 
 		if (updateSequence === this._updateSequence) {
 			this._panel.webview.html = html;
@@ -612,6 +672,11 @@ export class PreviewPanel {
 				error: new Error(`Failed to load Handlebars helpers from ${this._helperUri.toString()}: ${error}`)
 			};
 		}
+	}
+
+	private setMode(mode: PreviewMode) {
+		this._mode = mode;
+		this._panel.title = getPreviewTitle(mode);
 	}
 
 	private async generateHtmlPreview(useActiveEditor: boolean): Promise<string> {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -138,4 +138,26 @@ suite('extension', () => {
 			await config.update('backgroundColor', previousBackgroundColor, vscode.ConfigurationTarget.Global);
 		}
 	});
+
+	test('opens source preview command with escaped rendered output', async () => {
+		const extensionUri = vscode.extensions.getExtension('chaliy.handlebars-preview')?.extensionUri;
+		assert.ok(extensionUri);
+
+		const document = await vscode.workspace.openTextDocument(
+			vscode.Uri.joinPath(extensionUri, 'src/test/examples/simple.handlebars')
+		);
+
+		await vscode.window.showTextDocument(document);
+		const html = await vscode.commands.executeCommand<string>('handlebars.previewSource');
+
+		assert.ok(html);
+		assert.match(html, /<title>Handlebars Source Preview<\/title>/);
+		assert.match(html, /<pre><code>Super bar!\nComparison helper ok!\n<\/code><\/pre>/);
+
+		const webviewTabs = vscode.window.tabGroups.all
+			.flatMap(group => group.tabs)
+			.filter(tab => tab.input instanceof vscode.TabInputWebview);
+
+		assert.ok(webviewTabs.some(tab => tab.label === 'Handlebars Source Preview'));
+	});
 });

--- a/src/test/suite/lib/PreviewPanel.test.ts
+++ b/src/test/suite/lib/PreviewPanel.test.ts
@@ -6,6 +6,7 @@ import {
   getPartialUrisFromConfigurationValues,
   getWatchDirectoriesForUris,
   getWebviewOptions,
+  renderPreviewBody,
   renderWebviewDocument,
   rewriteLocalFontUrls,
   sanitizeBackgroundColor
@@ -155,5 +156,20 @@ suite("lib/PreviewPanel", () => {
 
     assert.match(html, /<body>/);
     assert.doesNotMatch(html, /background-color/);
+  });
+
+  test("renders source preview body as escaped whitespace-preserving code", () => {
+    const body = renderPreviewBody("<section>\n  Hello & goodbye\n</section>", "source");
+
+    assert.equal(
+      body,
+      "<main class=\"source-preview\" aria-label=\"Generated source preview\"><pre><code>&lt;section&gt;\n  Hello &amp; goodbye\n&lt;/section&gt;</code></pre></main>",
+    );
+  });
+
+  test("leaves visual preview body unchanged", () => {
+    const body = renderPreviewBody("<section>Hello</section>", "visual");
+
+    assert.equal(body, "<section>Hello</section>");
   });
 });


### PR DESCRIPTION
## What
Add a source preview mode for generated Handlebars output.

## Why
Addresses requests to inspect generated HTML/source markup and to preserve whitespace/newlines for non-HTML text/code output.

## How
- Adds `Handlebars: Open Source Preview` alongside the existing visual preview command.
- Keeps visual preview behavior unchanged.
- Escapes generated output in source mode and renders it inside a whitespace-preserving `<pre><code>` surface.
- Keeps webview scripts disabled and preserves the existing restrictive CSP, local resource rewriting, and background color handling.
- Updates README, changelog, specs, and regression coverage.

## Verification
- `npm run compile`
- `npm run lint`
- `npm test` - 40 passing
- `npm run test:web` - 35 passing
- `npm run package`

Fixes #1.
Fixes #4.
