### PR TITLE
ci(release): automate marketplace publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,129 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  marketplace:
+    name: Publish to Visual Studio Marketplace
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag
+        id: validate
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: publish must run from a stable vX.Y.Z tag"
+            exit 1
+          fi
+
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          LOCK_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+          EXTENSION_ID=$(node -p "const p=require('./package.json'); p.publisher + '.' + p.name")
+          VSIX="handlebars-preview-$TAG.vsix"
+
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Error: tag version $VERSION does not match package.json $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          if [ "$VERSION" != "$LOCK_VERSION" ]; then
+            echo "Error: tag version $VERSION does not match package-lock.json $LOCK_VERSION"
+            exit 1
+          fi
+
+          git fetch --force origin "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" "refs/tags/$TAG:refs/tags/$TAG"
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          SOURCE_SHA=$(git rev-parse HEAD)
+
+          if [ "$TAG_SHA" != "$SOURCE_SHA" ]; then
+            echo "Error: workflow source $SOURCE_SHA does not match $TAG at $TAG_SHA"
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TAG_SHA" "origin/$DEFAULT_BRANCH"; then
+            echo "Error: publish source $TAG_SHA is not reachable from origin/$DEFAULT_BRANCH"
+            exit 1
+          fi
+
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "extension_id=$EXTENSION_ID"
+            echo "vsix=$VSIX"
+          } >> "$GITHUB_OUTPUT"
+          echo "Publish source verified: $TAG at $TAG_SHA"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: xvfb-run -a npm test
+
+      - name: Test Web
+        run: xvfb-run -a npm run test:web
+
+      - name: Package VSIX
+        run: npm run package -- --out "${{ steps.validate.outputs.vsix }}"
+
+      - name: Upload VSIX to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.validate.outputs.tag }}" "${{ steps.validate.outputs.vsix }}" --clobber
+
+      - name: Publish to Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npm run publish -- --packagePath "${{ steps.validate.outputs.vsix }}"
+
+      - name: Verify Marketplace version
+        run: |
+          EXPECTED="${{ steps.validate.outputs.version }}"
+          EXTENSION_ID="${{ steps.validate.outputs.extension_id }}"
+          ATTEMPTS=24
+          SLEEP_SECONDS=10
+
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            ACTUAL=$(npx --no-install vsce show "$EXTENSION_ID" --json 2>/dev/null | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => { try { const data = JSON.parse(input); console.log(data.version || 'not found'); } catch { console.log('not found'); } });")
+
+            if [ "$ACTUAL" = "$EXPECTED" ]; then
+              echo "$EXTENSION_ID@$ACTUAL is visible on the Marketplace"
+              exit 0
+            fi
+
+            echo "Attempt $attempt/$ATTEMPTS: expected $EXPECTED on the Marketplace, got $ACTUAL"
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
+
+          echo "Error: expected $EXTENSION_ID@$EXPECTED on the Marketplace after $ATTEMPTS attempts"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+              echo "Error: manual releases must run from refs/heads/$DEFAULT_BRANCH"
+              exit 1
+            fi
+            VERSION=$(node -p "require('./package.json').version")
+          else
+            FIRST_LINE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+            VERSION=$(printf '%s\n' "$FIRST_LINE" | sed -n 's/^chore(release): prepare v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "Error: could not determine release version"
+            exit 1
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "tag=v$VERSION"
+          } >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Verify version metadata
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          LOCK_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Error: release version $VERSION does not match package.json $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          if [ "$VERSION" != "$LOCK_VERSION" ]; then
+            echo "Error: release version $VERSION does not match package-lock.json $LOCK_VERSION"
+            exit 1
+          fi
+
+          if ! grep -Fq "## [$VERSION]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md is missing a ## [$VERSION] section"
+            exit 1
+          fi
+
+          echo "Version metadata verified: $VERSION"
+
+      - name: Verify release source is on default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch --force origin "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH"; then
+            echo "Error: release source $GITHUB_SHA is not reachable from origin/$DEFAULT_BRANCH"
+            exit 1
+          fi
+          echo "Release source $GITHUB_SHA is reachable from origin/$DEFAULT_BRANCH"
+
+      - name: Extract release notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          awk -v version="$VERSION" '
+            index($0, "## [" version "]") == 1 { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release_notes.md
+
+          if [ ! -s release_notes.md ]; then
+            echo "Error: CHANGELOG.md section for $VERSION has no release notes"
+            exit 1
+          fi
+
+          echo "Release notes extracted for v$VERSION"
+
+      - name: Create and verify tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/$TAG" | awk '{print $1}')
+
+          if [ -n "$REMOTE_TAG_SHA" ]; then
+            git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+            TAG_SHA=$(git rev-list -n 1 "$TAG")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "Error: existing tag $TAG points to $TAG_SHA, expected $GITHUB_SHA"
+              exit 1
+            fi
+            echo "Existing tag $TAG verified at $GITHUB_SHA"
+          else
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
+            echo "Created tag $TAG at $GITHUB_SHA"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "Release $TAG" --notes-file release_notes.md
+          else
+            gh release create "$TAG" --title "Release $TAG" --notes-file release_notes.md --verify-tag
+          fi
+
+      - name: Verify release tag points to this commit
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+            echo "Error: release tag $TAG points to $TAG_SHA, expected $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Release tag $TAG verified at $TAG_SHA"
+
+      - name: Trigger Marketplace publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh workflow run publish.yml --ref "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,67 @@
-# Change Log
+# Changelog
+
+## [Unreleased]
 
 ## [2.0.0] - Unreleased
-- Breaking change: minimum supported VS Code version is now 1.125.0.
-- Upgrade TypeScript, ESLint, VS Code test tooling, and VS Code API types.
-- Replace webpack with an esbuild bundle that also exposes a VS Code Web `browser` entry.
-- Use VS Code URI and workspace filesystem APIs so previews work in web and virtual workspaces.
-- Add browser-based VS Code Web tests with `npm run test:web`.
-- Add `.handlebars` and `.hbs` language contributions and a configurable preview data suffix.
-- Refresh previews when the template or adjacent JSON data file changes on disk.
-- Harden preview webviews by disabling scripts and adding a restrictive content security policy.
-- Support local `@font-face` fonts referenced from the active template directory.
-- Escape renderer error output before showing it in the preview.
-- Replace the legacy `glob` test dependency with a local test-file loader.
-- Remove the legacy custom `@vscode/test-electron` runner entrypoint.
-- Add regression coverage for missing/invalid JSON context, escaped render errors, preview command wiring, and rendered preview output.
-- Add GitHub Actions CI for compile, lint, desktop tests, web tests, audit, and package validation.
-- Add `Handlebars: Load Partials` for workspace-configured partial files.
-- Refresh previews when configured partial files change, without watching the
-  entire workspace.
-- Add opt-in custom helper loading for trusted desktop workspaces through
-  `handlebarsPreview.unsafeHelpers.*` settings.
-- Add `handlebarsPreview.backgroundColor` to override the preview webview background.
-- Add built-in `compare`, `eq`, and safe identity `eval` compatibility helpers.
-- Add `Handlebars: Open Source Preview` to inspect escaped generated output and preserve whitespace for non-HTML text/code rendering.
+
+### Highlights
+
+- **VS Code Web and virtual workspace support** - the extension now uses VS Code
+  URI and workspace filesystem APIs, exposes a browser entry point, and includes
+  browser-based tests with `npm run test:web`.
+- **Richer live preview inputs** - previews can load selected partials, read a
+  configurable data-file suffix, watch template/data/partial edits, and load
+  local `@font-face` assets from the template directory.
+- **Safer preview rendering** - webviews run with scripts disabled, use a
+  restrictive content security policy, and escape renderer error output before
+  showing it in the preview.
+- **Helper compatibility** - built-in `compare`, `eq`, and safe identity `eval`
+  helpers are available by default, with opt-in custom helper loading for
+  trusted desktop workspaces.
+- **Source preview mode** - `Handlebars: Open Source Preview` shows escaped
+  generated output while preserving whitespace for non-HTML text/code rendering.
+- **Modern maintenance and release automation** - the project now builds with
+  esbuild, runs GitHub Actions CI for compile/lint/tests/audit/package
+  validation, and creates tagged GitHub Releases with automatic Marketplace
+  publishing.
+
+### Breaking Changes
+
+- **Minimum supported VS Code version is now 1.125.0.** Users on older VS Code
+  versions must upgrade before installing this release.
+
+### What's Changed
+
+* build: upgrade TypeScript, ESLint, VS Code test tooling, and VS Code API types
+* build: replace webpack with an esbuild bundle and VS Code Web browser entry
+* feat(preview): support VS Code Web and virtual workspaces
+* feat(preview): add `.handlebars` and `.hbs` language contributions
+* feat(preview): add configurable preview data suffix
+* feat(preview): refresh when templates or adjacent JSON data files change
+* feat(preview): load selected workspace partial files and refresh on edits
+* feat(preview): support local `@font-face` fonts from the template directory
+* feat(preview): add configurable preview webview background color
+* feat(preview): add opt-in trusted workspace custom helper loading
+* feat(preview): add source preview mode for escaped generated output
+* fix(preview): disable webview scripts and add a restrictive content security policy
+* fix(preview): escape renderer error output before showing it
+* fix(preview): add built-in `compare`, `eq`, and safe identity `eval` helpers
+* test: add browser-based VS Code Web tests
+* test: add regression coverage for JSON context, escaped render errors, command wiring, and rendered preview output
+* test: replace the legacy `glob` dependency with a local test-file loader
+* test: remove the legacy custom `@vscode/test-electron` runner entrypoint
+* ci: add GitHub Actions CI for compile, lint, desktop tests, web tests, audit, and package validation
+* ci: add tagged GitHub Release and Marketplace publishing workflows
+
+**Full Changelog**: https://github.com/chaliy/vscode-handlebars-preview/compare/v1.3.2...v2.0.0
+
+## [1.3.2] - 2026-07-04
+
+### What's Changed
+
+* chore(release): refresh package metadata for Marketplace publishing
+
+**Full Changelog**: https://github.com/chaliy/vscode-handlebars-preview/compare/v1.3.1...v1.3.2
 
 ## [1.3.1] - 2022-07-19
 - Extension now contributes to Explorer context menu

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
         console: 'readonly',
         process: 'readonly',
         suite: 'readonly',
+        teardown: 'readonly',
         test: 'readonly'
       }
     },

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "lint": "eslint src",
     "test": "vscode-test",
     "test:web": "npm run compile && npm run compile:web-test && vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=out/web/test/extensionTests.js .",
+    "release:check": "npm run compile && npm run lint && npm test && npm run test:web && npm run package",
     "publish": "vsce publish",
     "package": "vsce package"
   },

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -2,25 +2,55 @@
 
 ## Status
 
-Active
+Implemented
 
 ## Purpose
 
 Define the release expectations for publishing the VS Code extension.
 
-## Requirements
+## Release Workflow
 
-- Release changes must pass `npm run compile`, `npm run lint`, and `npm test`.
-- Web-compatible runtime or manifest changes must also pass
-  `npm run test:web`.
-- Public behavior changes must be reflected in `README.md` and `CHANGELOG.md`.
-- `package.json` metadata, commands, keybindings, and version must match the
-  release being published.
-- Package validation should run with `npm run package` before publishing.
-- Publish with `npm run publish` only after checks pass and the package contents
-  have been reviewed.
-- After publishing, wait until Marketplace metadata and a fresh extension
-  install both report the new version before considering the release complete.
+Flow: **prepare -> verify-can-publish -> merge -> publish -> monitor**.
+
+1. Prepare a release PR with `package.json`, `package-lock.json`, and
+   `CHANGELOG.md` updated for `vX.Y.Z`.
+2. Run `npm run release:check` before opening or merging the release PR.
+3. Merge a commit titled `chore(release): prepare vX.Y.Z` to the default
+   branch.
+4. `.github/workflows/release.yml` creates or verifies tag `vX.Y.Z`, extracts
+   release notes from `CHANGELOG.md`, creates the GitHub Release, then
+   dispatches `.github/workflows/publish.yml` on the tag.
+5. `.github/workflows/publish.yml` rebuilds from the tag, runs compile, lint,
+   desktop tests, web tests, packages the VSIX, uploads the VSIX to the GitHub
+   Release, publishes to the Visual Studio Marketplace, and verifies the
+   Marketplace version.
+
+The publish workflow uses the `VSCE_PAT` GitHub Actions secret. Keep the token
+scoped to Marketplace publishing for publisher `chaliy`.
+
+## Human Steps
+
+1. Ask the agent to create a release, for example `Create release v2.1.0`.
+2. Review the release PR, including changelog notes and verification output.
+3. Merge the release PR to the default branch.
+4. Monitor the release and publish workflows until the GitHub Release, VSIX
+   asset, and Marketplace listing all show the new version.
+
+## Agent Steps
+
+1. Ensure git history and tags are available:
+   `git fetch --tags --unshallow origin 2>/dev/null || git fetch --tags origin`.
+2. Determine the release version from the requested scope and semantic
+   versioning.
+3. Update `package.json` and `package-lock.json` to the same version.
+4. Move `CHANGELOG.md` entries from `[Unreleased]` into a dated
+   `## [X.Y.Z] - YYYY-MM-DD` section.
+5. Run `npm run release:check`.
+6. Commit as `chore(release): prepare vX.Y.Z`, open a focused PR, and include
+   the changelog excerpt plus verification results.
+7. After merge, monitor `release.yml` and `publish.yml`; if publishing fails,
+   fix the root cause in a follow-up patch release rather than leaving a
+   partial release undocumented.
 
 ## Versioning
 
@@ -31,6 +61,34 @@ Define the release expectations for publishing the VS Code extension.
 - When the minimum VS Code engine changes, the release notes must call it out as
   a breaking change.
 
+## Changelog Format
+
+Use this structure:
+
+```markdown
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Highlights
+
+- **Short user-facing summary** - impact and context.
+
+### Breaking Changes
+
+- **Short summary** - migration notes when needed.
+
+### What's Changed
+
+* type(scope): description ([#N](https://github.com/chaliy/vscode-handlebars-preview/pull/N)) by @author
+
+**Full Changelog**: https://github.com/chaliy/vscode-handlebars-preview/compare/vA.B.C...vX.Y.Z
+```
+
+Omit `### Breaking Changes` when there are none. Keep `### Highlights` to the
+few items users should notice first, and use `### What's Changed` for the
+complete release body.
+
 ## Release Readiness
 
 A release is ready when the package installs, the preview command opens, sample
@@ -40,3 +98,9 @@ After publishing, smoke test the Marketplace-installed extension in an isolated
 VS Code profile. Confirm the installed version matches `package.json`, the
 preview command activates the extension, and a sample template opens a preview
 panel.
+
+## Rollback
+
+Marketplace releases cannot be safely overwritten. If a bad version is
+published, immediately prepare a patch release that fixes or reverts the issue,
+then publish it through the same workflow.

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -18,6 +18,10 @@ function delay(ms: number): Promise<void> {
 }
 
 suite('extension', () => {
+	teardown(async () => {
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+
 	test('activation', () => {
 		assert.ok(extension.activate);
 	});


### PR DESCRIPTION
## What
Add Bashkit-style release automation for the VS Code extension: a release workflow that creates/verifies vX.Y.Z tags and GitHub Releases, plus a publish workflow that packages, uploads, publishes to the Visual Studio Marketplace, and verifies the Marketplace version.

## Why
Releases should be repeatable: changelog, tags, GitHub Releases, VSIX artifacts, Marketplace publishing, and post-publish verification should all follow one documented path.

## How
- Add `.github/workflows/release.yml` for release-prep commits and manual default-branch dispatches.
- Add `.github/workflows/publish.yml` for tag-validated Marketplace publishing using `VSCE_PAT`.
- Document the prepare -> verify -> merge -> publish -> monitor process in `specs/release-process.md`.
- Update `CHANGELOG.md` to the release-notes format consumed by automation.
- Add `npm run release:check`.
- Isolate integration tests by closing editors between extension tests.

## First-release readiness
- Confirmed repository secret `VSCE_PAT` exists.
- Confirmed GitHub environment `release` exists.
- Confirmed Actions workflow token default is `write`, allowing tag/release/dispatch operations.
- Confirmed workflow syntax and shell checks with `actionlint`.

## Verification
- `actionlint`
- `git diff --check`
- `npm run release:check`

## Risk
Medium: this introduces release/publish automation. The publish workflow is gated to stable `vX.Y.Z` tags, verifies tag/package/lockfile version alignment, rebuilds and retests from the tag, uploads the VSIX to the GitHub Release, and polls the Marketplace after publishing.

## Follow-ups
After CI passes on this PR, merge the actual release prep commit with title `chore(release): prepare v2.0.0` when you want the first automated publish to run.