### PR TITLE
fix(ci): verify marketplace version from vsce metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Publish to Marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npm run publish -- --packagePath "${{ steps.validate.outputs.vsix }}"
+        run: npm run publish -- --packagePath "${{ steps.validate.outputs.vsix }}" --skip-duplicate
 
       - name: Verify Marketplace version
         run: |
@@ -112,7 +112,7 @@ jobs:
           SLEEP_SECONDS=10
 
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            ACTUAL=$(npx --no-install vsce show "$EXTENSION_ID" --json 2>/dev/null | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => { try { const data = JSON.parse(input); console.log(data.version || 'not found'); } catch { console.log('not found'); } });")
+            ACTUAL=$(npx --no-install vsce show "$EXTENSION_ID" --json 2>/dev/null | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => { try { const data = JSON.parse(input); console.log(data.version || data.versions?.[0]?.version || 'not found'); } catch { console.log('not found'); } });")
 
             if [ "$ACTUAL" = "$EXPECTED" ]; then
               echo "$EXTENSION_ID@$ACTUAL is visible on the Marketplace"


### PR DESCRIPTION
## What
Fix the Marketplace publish verifier to read the current version from `vsce show --json` metadata at `versions[0].version`, and make publish reruns idempotent with `--skip-duplicate`.

## Why
The first automated publish succeeded, but the final verifier failed because it expected a top-level `version` field that `vsce show --json` does not return.

## Verification
- `actionlint`
- `git diff --check`
- Direct `vsce show chaliy.handlebars-preview --json` parse confirmed `2.0.0`

## Published state
- GitHub Release `v2.0.0` exists with uploaded VSIX.
- Marketplace metadata reports `chaliy.handlebars-preview` version `2.0.0`.